### PR TITLE
Can I get an alfsteel AIOT instead of terrasteel?

### DIFF
--- a/contributors/aiotbotania.properties
+++ b/contributors/aiotbotania.properties
@@ -6,5 +6,5 @@
 4d16bc6b-2ff3-40c7-910c-e7472d12e6cd=manasteel_aiot
 00e18196-b1e9-447a-bfc9-8509f126be46=livingwood_aiot
 e8034872-753d-46f8-8d8d-5f39e6ae1220=livingwood_aiot
-3358ddae-3a41-4ba0-bdfa-ee54b6c55cf5=terra_aiot
+3358ddae-3a41-4ba0-bdfa-ee54b6c55cf5=alfsteel_aiot
 ab5a4cf9-dc0b-4493-bfe0-cd61cc9bd857=terra_hoe


### PR DESCRIPTION
Now that AIOT Botania has support for MythicBotany, I would prefer an alfsteel AIOT over a terrasteel AIOT for display.